### PR TITLE
(Suggestion) 'One of ALL'

### DIFF
--- a/LUI_BossMods.lua
+++ b/LUI_BossMods.lua
@@ -358,11 +358,14 @@ function LUI_BossMods:CheckTrigger(tModule)
             if not self.tSavedUnits[sName] then
                 return false
             else
+				local combat = false
                 for nId, unit in pairs(self.tSavedUnits[sName]) do
-                    if not unit:IsInCombat() then
-                        return false
+                    if unit:IsInCombat() then
+                        combat = true
+						break
                     end
                 end
+				if not combat then return false end
             end
         end
 


### PR DESCRIPTION
One of my biggest problems as i tried to implement the DS-Pairs was, that the tSavedUnits were populated with more than one unit of each boss.
 I know you made fixes to encounter this problem and at least after this commit the problem stayed: 

> Fixed a problem of tSavedUnits not getting cleaned up and therfor prevented boss trigger "all" from working properly.

Currently 'ALL'-triggers check for 'Every of all' and 'ANY'-triggers check for 'One of any'. This Commit would change 'ALL'-triggers to 'One of all'.

What do you think? (Just close it, if you dont like the idea at all)

-Mischh
