### PR TITLE
DS WaterFire: Localizations, Bomb Icons, Line to other Bombs

### DIFF
--- a/Encounters/DS/Pairs/PyrobaneHydroflux.lua
+++ b/Encounters/DS/Pairs/PyrobaneHydroflux.lua
@@ -17,15 +17,60 @@ local Locales = {
         ["text.next_ice_tomb"] = "Next ice tomb",
         -- Labels
         ["label.bombs"] = "Bombs",
+        ["label.fireBombs"] = "Fire bombs",
+        ["label.waterBombs"] = "Water bombs",
         ["label.ice_tomb"] = "Ice Tomb",
         ["label.flame_waves"] = "Flame Waves",
+		--Messages
+		["message.bombs"] = "Bombs!",
+		["message.ice_tomb"] = "Ice Tombs!",
     },
-    ["deDE"] = {},
-    ["frFR"] = {},
+    ["deDE"] = {
+        -- Unit names
+        ["unit.boss_fire"] = "Pyroman",
+        ["unit.boss_water"] = "Hydroflux",
+        ["unit.ice_tomb"] = "Eisgrab",
+        ["unit.flame_wave"] = "Flammenwelle",
+        -- Texts
+        ["text.next_bombs"] = "Nächste Bomben",
+        ["text.next_ice_tomb"] = "Nächstes Eisgrab",
+        -- Labels
+        ["label.bombs"] = "Bomben",
+        ["label.fireBombs"] = "Feuer-Bomben",
+        ["label.waterBombs"] = "Wasser-Bomben",
+        ["label.ice_tomb"] = "Eisgrab",
+        ["label.flame_waves"] = "Flammenwellen",
+		--Messages
+		["message.bombs"] = "Bomben!",
+		["message.ice_tomb"] = "Eisgräber!",
+	},
+    ["frFR"] = {
+		-- Unit names
+        ["unit.boss_fire"] = "Pyromagnus",
+        ["unit.boss_water"] = "Hydroflux",
+        ["unit.ice_tomb"] = "Tombeau de glace",
+        ["unit.flame_wave"] = "Vague de feu",
+        -- Texts
+        ["text.next_bombs"] = "Prochaine bombes",
+        ["text.next_ice_tomb"] = "Prochain tombeau de glace",
+        -- Labels
+        ["label.bombs"] = "Bombes",
+        ["label.fireBombs"] = "Fire bombs", --translate please.
+        ["label.waterBombs"] = "Water bombs", --translate please.
+        ["label.ice_tomb"] = "Tombeau de glace",
+        ["label.flame_waves"] = "Vague de feu",
+		--Messages
+		["message.bombs"] = "Bombes!",
+		["message.ice_tomb"] = "Tombeau de glace!",
+	},
 }
 
 local nLastBombTime = 0
 local nLastIceTombTime = 0
+local tFrostBombs = {} --all fire-bombs; [unitId] = true
+local tFireBombs = {} --all frost-bombs
+local tBombLines = {} --map of all id's used for bomb-lines; [unitId] = "KeyUsedToCreateLine"
+
 local DEBUFF_FROSTBOMB = 75058
 local DEBUFF_FIREBOMB = 75059
 local DEBUFF_ICE_TOMB = 74326
@@ -102,6 +147,22 @@ function Mod:new(o)
                 label = "label.ice_tomb",
             },
         },
+		icons = {
+			fireBombs = {
+                enable = true,
+                sprite = "LUIBM_bomb",
+                size = 40,
+                color = "ffff2f2f",
+                label = "label.fireBombs",
+			},
+			waterBombs = {
+                enable = true,
+                sprite = "LUIBM_bomb",
+                size = 40,
+                color = "ff1e1eff",
+                label = "label.waterBombs",
+			},
+		},
         lines = {
             flame_wave = {
                 enable = true,
@@ -109,8 +170,14 @@ function Mod:new(o)
                 color = "ffff0000",
                 label = "label.flame_waves",
             },
+			bombs = { --line to bombs of the other type (relative to your current bomb)
+                enable = true,
+                thickness = 7,
+                label = "label.bombs",
+			},
         },
     }
+	
     return o
 end
 
@@ -119,6 +186,19 @@ function Mod:Init(parent)
 
     self.core = parent
     self.L = parent:GetLocale(Encounter,Locales)
+end
+
+function Mod:DrawBombLines()
+	local player = GameLib.GetPlayerUnit()
+	local nId = player:GetId()
+	
+	local otherBombs = tFireBombs[nId] and tFrostBombs or tFrostBombs[nId] and tFireBombs or {}
+	
+	for id in pairs(otherBombs) do
+		local key = "bombLine"..id
+		tBombLines[id] = key
+		self.core:DrawLineBetween(key, player, id, self.config.lines.bombs)
+	end
 end
 
 function Mod:OnUnitCreated(nId, tUnit, sName, bInCombat)
@@ -147,13 +227,43 @@ function Mod:OnBuffAdded(nId, nSpellId, sName, tData, sUnitName, nStack, nDurati
         if nCurrentTime - nLastBombTime > 10 then
             nLastBombTime = nCurrentTime
             self.core:AddTimer("BOMBS", self.L["message.bombs"], 30, self.config.timers.bombs)
+			
+			tFrostBombs = {}
+			tFireBombs = {}
         end
+		if tData.tUnit:IsThePlayer() then
+			ApolloTimer.Create(1, false, "DrawBombLines", self)
+		end
+		if nSpellId == DEBUFF_FIREBOMB then
+			self.core:DrawPixie(nId, tData.tUnit, self.config.icons.fireBombs, 0, 0, 2)
+			tFireBombs[nId] = true
+		else
+			self.core:DrawPixie(nId, tData.tUnit, self.config.icons.waterBombs, 0, 0, 2)
+			tFrostBombs[nId] = true
+		end		
     elseif nSpellId == DEBUFF_ICE_TOMB then
         local nCurrentTime = GameLib.GetGameTime()
         if nCurrentTime - nLastIceTombTime > 5 then
             nLastIceTombTime = nCurrentTime
             self.core:AddTimer("ICE_TOMB", self.L["message.ice_tomb"], 15, self.config.timers.ice_tomb)
         end
+    end
+end
+
+function Mod:OnBuffRemoved(nId, nSpellId, sName, tData, sUnitName)
+    if nSpellId == DEBUFF_FIREBOMB or nSpellId == DEBUFF_FROSTBOMB then
+		self.core:RemoveIcon(nId)
+		if tData.tUnit:IsThePlayer() then
+			for id, key in pairs(tBombLines) do
+				self.core:RemoveLineBetween(key)
+			end
+			tBombLines = {}
+		elseif tBombLines[nId] then
+			self.core:RemoveLineBetween(tBombLines[nId])
+			tBombLines[nId] = nil
+		end
+		tFrostBombs[nId] = nil
+		tFireBombs[nId] = nil
     end
 end
 
@@ -169,6 +279,9 @@ function Mod:OnEnable()
     self.run = true
     nLastIceTombTime = 0
     nLastBombTime = 0
+	tFrostBombs = {}
+	tFireBombs = {}
+	tBombLines = {}
 
     self.core:AddTimer("BOMBS", self.L["message.bombs"], 30, self.config.timers.bombs)
     self.core:AddTimer("ICE_TOMB", self.L["message.ice_tomb"], 26, self.config.timers.ice_tomb)


### PR DESCRIPTION
Hey there!

Just added the Localizations, which were missing, Added Icons(Sprites to be exact) to everyone having a Bomb on themselves and drew Lines between you and all of the other bomb-types, if you have got a bomb on yourself.

One thing i had a real problem with: Icons.
Seems these 'WorldFixedWindow'-things are not supposed to be shown, if occluded. For me, it did not update its position, if occluded. Which resulted in very weird placements. This may need a very close look.

When to prefer these over Pixies?

Btw: Are you aware, the parameter 'nHeight' in :DrawIcon() should be a Enum to choose where to anchor the Icon? (0=feet, 1=head, didnt research more - but 20 results in feet)

-Mischh
